### PR TITLE
fix: cloudflare worker types bug for DO RPC

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 		"module": "esnext",
 		"lib": ["esnext"],
 		"declaration": true,
-		"types": ["@cloudflare/workers-types/experimental"],
+		"types": ["@cloudflare/workers-types"],
 		"moduleResolution": "node",
 		"strict": true,
 		"outDir": "dist",


### PR DESCRIPTION
For some reason `@cloudflare/workers-types/experimental` breaks types for DO RPC. you get the following error: ```DurableObjectNamespace<DOClass>` anymore without stumbling on `Type 'DOClass' does not satisfy the constraint 'DurableObjectBranded'.
  Property '[__DURABLE_OBJECT_BRAND]' is missing in type 'DOClass' but required in type 'DurableObjectBranded'.```

I changed the `@cloudflare/workers-types/experimental` to `@cloudflare/workers-types` and it works.